### PR TITLE
Reduce CA Validity to 825 Days

### DIFF
--- a/bin/ca-gen
+++ b/bin/ca-gen
@@ -8,7 +8,7 @@ NAME="ca-gen"
 
 # Generate default options
 DEF_KEYSIZE=2048
-DEF_DAYS=3650
+DEF_DAYS=825
 DEF_SIGN_SIGNATURE="sha256"
 # Subject default options
 DEF_COUNTRY=


### PR DESCRIPTION
Modified ca_gen DEF_DAYS=825 to support new restrictions for Trusted Certificates on Apple OS.  

This now matches the DEF_DAYS used in cert-gen.

See: https://support.apple.com/en-us/HT210176